### PR TITLE
Added printer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Available variables:
 - mkopts="" # Default arguments for makepkg
 - replace_deps={"vte" : "vte-legacy"} # Items in dependency which should be replaced with another one
 - black=[] # Blacklist, package names in this list will be excluded at updates. The names have to be python strings and seperated by commas. black=["brave-bin", "cava"]
+- `printer` # The printer/executable that will be used to print the contents of AUR files. Example: [`bat -P`](https://github.com/sharkdp/bat)
 
 Bash only options:
 - sudoreset=1 # Reset sudo before PKGBUILD

--- a/buildaur
+++ b/buildaur
@@ -315,7 +315,10 @@ def install(pkgs):
                     try:
                         if showPKGBUILD:
                             print(trans["print_pkgb"]%(file))
-                            print("\033[37m"+str(open(file, "rt").read())+"\033[0m", end="")
+                            if printer is None:
+                                print("\033[37m" + str(open(file, "rt").read()) + "\033[0m", end="")
+                            else:
+                                os.system(f"{printer} {file}")
                         ask = input(trans["edit"]%(file)) if options.confirm else trans["no"]
                         if ask in [trans["yes"], trans["yes"].capitalize()]:
                             os.system(editor+" "+file)
@@ -588,6 +591,7 @@ localdb = handle.get_localdb()
 legitimator = "sudo"
 args = sys.argv
 black = []
+printer = None
 
 if __name__ == "__main__":
     readline.parse_and_bind('tab: complete')

--- a/buildaur.conf
+++ b/buildaur.conf
@@ -18,6 +18,7 @@
 #black=[] # Blacklist, package names in this list will be excluded at updates. The names have to be python strings and seperated by commas. black=["brave-bin", "cava"]
 #legitimator="sudo" # A string of the legitimation program (like sudo or doas) you use
 #get_from_syncdb=True # True: buildaur gets AUR-packages via syncdbs (slow)(This may be usefull when having 3rd party repositorys) False: buildaur gets AUR-packages via packager (fast)
+#printer=None # Set this to an executable that will be used to print PKGBUILDs and other AUR files.
 # Bash only options:
 #sudoreset=1 # Reset sudo before PKGBUILD
 #layout="new" # Old or new look of buildaur


### PR DESCRIPTION
The printer/executable that will be used to print the contents of AUR files.

Example: [`bat -P`](https://github.com/sharkdp/bat)